### PR TITLE
Update PublicClient.php

### DIFF
--- a/src/Clients/PublicClient.php
+++ b/src/Clients/PublicClient.php
@@ -78,6 +78,9 @@ class PublicClient {
      */
     protected function get(array $uriParts, $type, array $options = []) {
         $response = $this->request(GDAXConstants::METHOD_GET, $uriParts, $options);
+        if (!is_array($response)) {
+            throw new \Exception('Received invalid response : ' . $response .' when expecting an array ');
+        }
         return (new ResponseContainer)->setRawData($response)->mapResponseToType($type)->getData();
     }
 


### PR DESCRIPTION
Validating response before setting data. This fixes the below error I have been getting every other day.

`PHP Fatal error:  Uncaught TypeError: Argument 1 passed to GDAX\Types\Response\ResponseContainer::setRawData() must be of the type array, integer given, called in /vendor/benfranke/gdax-php/src/Cl
ients/PublicClient.php on line 81 and defined in /vendor/benfranke/gdax-php/src/Types/Response/ResponseContainer.php:96
Stack trace:
#0 /vendor/benfranke/gdax-php/src/Clients/PublicClient.php(81): GDAX\Types\Response\ResponseContainer->setRawData(1)
#1 /vendor/benfranke/gdax-php/src/Clients/AuthenticatedClient.php(218): GDAX\Clients\PublicClient->get(Array, 'GDAX\\Types\\Resp...')
#2 /index.php(335): GDAX\Clients\AuthenticatedClient->getOrder(Object(GDAX\Types\Request\Authenticated\Order))
#3 /index.php(489): checkOrderStatus(Object(GDAX\Clients\AuthenticatedClient), 'd3348770-a55d-4...')
#4 {main}
  thrown in /vendor/benfranke/gdax-php/src/Types/Response/ResponseContainer.php on line 96`